### PR TITLE
Task text areas start with lower case character

### DIFF
--- a/qml/pages/DetailTask.qml
+++ b/qml/pages/DetailTask.qml
@@ -32,6 +32,7 @@ Dialog {
             label: qsTr("Description")
             text: description
             placeholderText: qsTr("Description")
+            inputMethodHints: Qt.ImhNoAutoUppercase
         }
         TextField {
             id: projectfield
@@ -39,6 +40,7 @@ Dialog {
             label: qsTr("Project")
             text: project
             placeholderText: qsTr("Project")
+            inputMethodHints: Qt.ImhNoAutoUppercase
         }
         Item {
             anchors.left: parent.left


### PR DESCRIPTION
The input method should not try to automatically switch to upper case when a sentence ends.
Since people want adding tasks very quickly they dont care about capital letters and omit them entirely.
The task list gets inconsistent when the input method automatically just sets the first character to an uppercase one.